### PR TITLE
ActivityStream - Fix show-more button not shown and add tests

### DIFF
--- a/containers/ActivityStream/endpoints.js
+++ b/containers/ActivityStream/endpoints.js
@@ -16,9 +16,8 @@ export default {
       if (params.page === 1 ||
           params.start !== last.getIn(['params', 'start']) ||
           params.end !== last.getIn(['params', 'end']))
-        return last
+        return next
           .set('params', fromJS(params))
-          .set('results', next.get('results'))
       return last
         .set('results', last.get('results').concat(next.get('results')))
         .set('params', fromJS(params))

--- a/containers/ActivityStream/endpoints.test.js
+++ b/containers/ActivityStream/endpoints.test.js
@@ -5,7 +5,7 @@ import endpoints from './endpoints'
 
 const { storeMethod } = endpoints.getActivities
 
-export const makeResults = (count = 3) => times(count, i => ({
+export const makeResults = (count = 10) => times(count, i => ({
   id: `${i}`,
   category: 'system',
   created_at: '2018-06-07T08:05:34.245412',
@@ -16,8 +16,8 @@ export const makeResults = (count = 3) => times(count, i => ({
 }))
 
 const makeResponse = ({
-  count = 3,
-  results = makeResults(count),
+  count = 25,
+  results = makeResults(),
 } = {}) => fromJS({
   count,
   results,
@@ -31,10 +31,27 @@ describe('ActivityStream storeMethod', () => {
       page: 1,
     }
     const results = makeResults()
-    const nextState = storeMethod(undefined, makeResponse({ results }), params)
+    const response = makeResponse({ results })
+    const nextState = storeMethod(undefined, response, params)
     expect(nextState).toEqual(fromJS({
       results,
       params,
+      count: 25,
+    }))
+  })
+  test('stores a reference to the total records count returned by server', () => {
+    const params = {
+      start: null,
+      end: null,
+      page: 1,
+    }
+    const results = makeResults()
+    const response = makeResponse({ count: 200, results })
+    const nextState = storeMethod(undefined, response, params)
+    expect(nextState).toEqual(fromJS({
+      results,
+      params,
+      count: 200,
     }))
   })
   test('concats results if start and end params match', () => {
@@ -45,7 +62,7 @@ describe('ActivityStream storeMethod', () => {
         end: null,
         page: 1,
       },
-      results: [1, 2, 3],
+      results: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     })
     const params = {
       start: null,
@@ -53,7 +70,7 @@ describe('ActivityStream storeMethod', () => {
       page: 2,
     }
     const nextState = storeMethod(state, makeResponse(), params)
-    expect(nextState.get('results').size).toEqual(6)
+    expect(nextState.get('results').size).toEqual(20)
   })
   test('over writes results if page 1', () => {
     const state = fromJS({
@@ -62,7 +79,7 @@ describe('ActivityStream storeMethod', () => {
         end: null,
         page: 2,
       },
-      results: [1, 2, 3, 4, 5],
+      results: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     })
     const params = {
       start: null,
@@ -71,6 +88,6 @@ describe('ActivityStream storeMethod', () => {
     }
     const results = makeResults()
     const nextState = storeMethod(state, makeResponse({ results }), params)
-    expect(nextState.get('results').size).toEqual(3)
+    expect(nextState.get('results').size).toEqual(10)
   })
 })


### PR DESCRIPTION
I broke `ActivityStream` when changing the `storeMethod` to use `last` instead of `next` which meant the `count` key was not being stored for comparing to the fetched results length.

I reverted that change and added some tests